### PR TITLE
Fix style crash when task is too long.

### DIFF
--- a/online_log/static/replay.html
+++ b/online_log/static/replay.html
@@ -34,8 +34,9 @@
         </div>
     </div>
     <div id="show" style="display: grid;">
-        <div id="humanRequest" style="position: relative;">
-            <p id="Requesttext" style=" color:aliceblue; display: block;font-weight: 900;">Task: </p>
+        
+        <div id="humanRequest" style="position: relative; overflow: auto;">
+            <p id="Requesttext" style=" color:aliceblue; display: block;font-weight: 900; max-height: 18px;">Task: </p>
         </div>
         <div id="dialogBody" style="top:20px;display: flex;flex-direction: column;">
         </div>


### PR DESCRIPTION
When the description is too long, the task grows too large and the style of the page breaks.