### PR TITLE
Make ChatDev more safe by adding a DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+# Use an official Python base image from the Docker Hub
+FROM python:3.9
+# Declare working directory
+WORKDIR /workspace/chatdev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+{
+    "dockerComposeFile": "./docker-compose.yml",
+    "service": "chatdev",
+    "workspaceFolder": "/workspace/chatdev",
+    "shutdownAction": "stopCompose",
+    "features": {
+      "ghcr.io/devcontainers/features/common-utils:2": {
+        "installZsh": "true",
+        "username": "vscode",
+        "userUid": "1000",
+        "userGid": "1000",
+        "upgradePackages": "true"
+      },
+      "ghcr.io/devcontainers/features/desktop-lite:1": {},
+      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/python:1": "none",
+      "ghcr.io/devcontainers/features/node:1": "none",
+      "ghcr.io/devcontainers/features/git:1": {
+        "version": "latest",
+        "ppa": "false"
+      }
+    },
+    // Configure tool-specific properties.
+    "customizations": {
+      // Configure properties specific to VS Code.
+      "vscode": {
+        // Set *default* container specific settings.json values on container create.
+        "settings": {
+          "python.defaultInterpreterPath": "/usr/local/bin/python",
+          "python.testing.pytestEnabled": true,
+          "python.testing.unittestEnabled": false
+        },
+        "extensions": [
+          "ms-python.python",
+          "VisualStudioExptTeam.vscodeintellicode",
+          "ms-python.vscode-pylance",
+          "ms-python.black-formatter",
+          "ms-python.isort",
+          "GitHub.vscode-pull-request-github",
+          "GitHub.copilot",
+          "github.vscode-github-actions"
+        ]
+      }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+  
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode",
+  
+    // Add the freshly containerized repo to the list of safe repositories and setup the requirements
+    "postCreateCommand": "git config --global --add safe.directory /workspace/chatdev && pip3 install --user -r requirements.txt"
+  }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,12 @@
+# To boot the app run the following:
+# docker-compose run chatdev
+version: '3.9'
+
+services:
+  chatdev:
+    build:
+      dockerfile: .devcontainer/Dockerfile
+      context: ../
+    tty: true
+    volumes:
+      - ../:/workspace/chatdev

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .DS_Store
 .idea
 .vscode
-
+.env

--- a/README.md
+++ b/README.md
@@ -38,7 +38,29 @@ https://github.com/OpenBMB/ChatDev/assets/11889052/80d01d2f-677b-4399-ad8b-f7af9
 
 ## ⚡️ Quickstart
 
-To get started, follow these steps:
+To get started safely, follow these steps:
+1. **Clone the GitHub Repository:** Begin by cloning the repository using the command:
+   ```
+   git clone https://github.com/OpenBMB/ChatDev.git
+   ```
+2. **Edit the .env file:** Create a .env with your OpenAI API key ()
+   ```
+   OPENAI_API_KEY="YOUR-OPENAI-SECRET-KEY-HERE"
+   ```
+3. **Launch the DevContainer:** Open the directory in VSCode with the DevContainer Extension and create/run the container.
+If you are not using VSCode, run the Docker in the .devcontainer folder.
+
+4. **Build Your Software:** Use the following command to initiate the building of your software, replacing `[description_of_your_idea]` with your idea's description and `[project_name]` with your desired project name in the VS Code Terminal:
+   ```
+   python3 run.py --task "[description_of_your_idea]" --name "[project_name]"
+   ```
+5. **Run Your Software:** Once generated, you can find your software in the `WareHouse` directory under a specific project folder, such as `project_name_DefaultOrganization_timestamp`. Run your software using the following command within that directory after reviewing it for saftey:
+   ```
+   cd WareHouse/project_name_DefaultOrganization_timestamp
+   python3 main.py
+   ```
+
+To get started UNSAFELY, follow these steps:
 
 1. **Clone the GitHub Repository:** Begin by cloning the repository using the command:
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ pyflakes==3.0.1
 pygame==2.5.1
 pylint==2.17.0
 PySocks==1.7.1
+python-dotenv==1.0.0
 python-engineio==4.5.1
 python-lsp-jsonrpc==1.0.0
 python-lsp-server==1.7.1

--- a/run.py
+++ b/run.py
@@ -15,6 +15,8 @@ import argparse
 import logging
 import os
 import sys
+from dotenv import load_dotenv
+load_dotenv()
 
 from camel.typing import ModelType
 


### PR DESCRIPTION
To improve the safety of a system that accesses LLM AIs over the internet and writes files to a filesystem, I have added a VSCode DevContainer. The Dockerfile could be used as a true Docker container with some modifications but at least this way your users are safer than without this patch so it lowers the overall probability of something going wrong.

I've updated the README to reflect this.