### PR TITLE
Add support for Ollama,  Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs) - using LiteLLM

### DIFF
--- a/camel/model_backend.py
+++ b/camel/model_backend.py
@@ -15,6 +15,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict
 
 import openai
+import litellm
 import tiktoken
 
 from camel.typing import ModelType
@@ -66,7 +67,7 @@ class OpenAIModel(ModelBackend):
         num_max_token = num_max_token_map[self.model_type.value]
         num_max_completion_tokens = num_max_token - num_prompt_tokens
         self.model_config_dict['max_tokens'] = num_max_completion_tokens
-        response = openai.ChatCompletion.create(*args, **kwargs,
+        response = litellm.completion(*args, **kwargs,
                                                 model=self.model_type.value,
                                                 **self.model_config_dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ jedi==0.18.2
 jieba==0.42.1
 Jinja2==3.1.2
 lazy-object-proxy==1.9.0
+litellm>=0.1.609
 Markdown==3.4.4
 MarkupSafe==2.1.3
 mccabe==0.7.0


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```