### PR TITLE
make sure test process can be killed on windows

### DIFF
--- a/chatdev/chat_env.py
+++ b/chatdev/chat_env.py
@@ -111,6 +111,8 @@ class ChatEnv:
                     os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                 else:
                     os.kill(process.pid, signal.SIGTERM)
+                    if process.poll() is None:
+                        os.kill(process.pid,signal.CTRL_BREAK_EVENT)
 
             if return_code == 0:
                 return False, success_info


### PR DESCRIPTION
Using ` signal.SIGTERM` sometimes does not work well on windows. Instead , use ` signal.CTRL_BREAK_EVENT` to make sure all kinds of subprocess for testing can be killed. 