### PR TITLE
Feat: Allow Azure ChatGPT usage

### DIFF
--- a/camel/model_backend.py
+++ b/camel/model_backend.py
@@ -13,6 +13,7 @@
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 from abc import ABC, abstractmethod
 from typing import Any, Dict
+import os
 
 import openai
 import tiktoken
@@ -71,6 +72,7 @@ class OpenAIModel(ModelBackend):
         self.model_config_dict['max_tokens'] = num_max_completion_tokens
         response = openai.ChatCompletion.create(*args, **kwargs,
                                                 model=self.model_type.value,
+                                                engine=os.getenv("OPENAI_API_ENGINE"),
                                                 **self.model_config_dict)
         cost = prompt_cost(
                 self.model_type.value, 


### PR DESCRIPTION
Adds variable "OPENAI_API_ENGINE", which is needed for the Azure API.

The Azure API requires the use of the 'engine' parameter in the ChatCompletion, ie, from the [documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/chatgpt?pivots=programming-language-chat-completions) 
```
import os
import openai
openai.api_type = "azure"
openai.api_version = "2023-05-15" 
openai.api_base = os.getenv("OPENAI_API_BASE")  # Your Azure OpenAI resource's endpoint value.
openai.api_key = os.getenv("OPENAI_API_KEY")

response = openai.ChatCompletion.create(
    engine="gpt-35-turbo", # The deployment name you chose when you deployed the GPT-35-Turbo or GPT-4 model.
    messages=[
        {"role": "system", "content": "Assistant is a large language model trained by OpenAI."},
        {"role": "user", "content": "Who were the founders of Microsoft?"}
    ]
)

print(response)

print(response['choices'][0]['message']['content'])
```

This patch lets you use your Azure ChatGPT account like so, by defining the engine and other data in environment variables, without affecting OpenAI use. It used like this:

`OPENAI_API_BASE="https://your_deployment_name.openai.azure.com/" OPENAI_API_TYPE=azure OPENAI_API_ENGINE=your_model_name OPENAI_API_VERSION=2023-05-15 OPENAI_API_KEY=your_secret_key python3 run.py --task "Snake game in pure html" --name "WebSnake"`

This has been tested with Azure and OpenAI APIs successfully.

