### PR TITLE
Fixed online_log module not found exception.

### DIFF
--- a/chatdev/utils.py
+++ b/chatdev/utils.py
@@ -6,7 +6,7 @@ import time
 import markdown
 import inspect
 from camel.messages.system_messages import SystemMessage
-from online_log.app import send_msg
+from chat_visualizer.app import send_msg
 
 
 def now():


### PR DESCRIPTION
Since the recent update to the name of `online_log` to `chat_visualizer`, there is a ModuleNotFoundException being thrown in utils.py.

This PR updates `online_log` to `chat_visualizer` resolving the issue:

## From:

![image](https://github.com/OpenBMB/ChatDev/assets/92177441/61837cbe-d03e-458b-94aa-d2cf37dc38e9)

## To:

![image](https://github.com/OpenBMB/ChatDev/assets/92177441/146db633-3e83-4c00-8cf9-100f1b9106c5)