### PR TITLE
feat: Proxied Model Support

### DIFF
--- a/chatdev/utils.py
+++ b/chatdev/utils.py
@@ -3,8 +3,11 @@ import logging
 import re
 import time
 
+from urllib.parse import urlparse
+
 import markdown
 import inspect
+
 from camel.messages.system_messages import SystemMessage
 from visualizer.app import send_msg
 
@@ -87,3 +90,10 @@ def escape_string(value):
     value = re.sub(r'<[^>]*>', '', value)
     value = value.replace("\n", " ")
     return value
+
+def is_url(url):
+  try:
+    result = urlparse(url)
+    return all([result.scheme, result.netloc])
+  except ValueError:
+    return False


### PR DESCRIPTION
This PR adds support for models served behind OpenAI-compatible proxies e.g. [LiteLLM](https://litellm.vercel.app/docs/simple_proxy) or [Bedrock Access Gateway](https://github.com/aws-samples/bedrock-access-gateway) (missing image generation support).

**Example (LiteLLM >> Amazon Bedrock)**

1. Set up AWS credentials

    ```bash
    export AWS_ACCESS_KEY_ID=...
    export AWS_SECRET_ACCESS_KEY=...
    export AWS_SESSION_TOKEN=...
    ```

2. Start LiteLLM proxy

    ```bash
    litellm --config config.yaml
    ```

    ```yaml
    # config.yaml
    # Adapted from https://litellm.vercel.app/docs/proxy/configs

    model_list:
    - model_name: claude3-sonnet
        litellm_params: 
        model: bedrock/anthropic.claude-3-sonnet-20240229-v1:0
        aws_region_name: us-east-1
    - model_name: sdxl
        litellm_params: 
        model: bedrock/stability.stable-diffusion-xl-v1
        aws_region_name: us-east-1

    litellm_settings: # module level litellm settings - https://github.com/BerriAI/litellm/blob/main/litellm/__init__.py
        drop_params: True

    general_settings: 
        master_key: correct-horse-battery-staple
   ```

3. Set up OpenAI and ChatDev env vars

    ```bash
    # OpenAI
    OPENAI_BASE_URL=http://0.0.0.0:4000
    OPENAI_API_KEY=correct-horse-battery-staple

    # ChatDev
    export CHATDEV_CUSTOM_MODEL=claude-3-sonnet
    export CHATDEV_NUM_MAX_TOKEN=200000
    export CHATDEV_CUSTOM_IMAGE_MODEL=sdxl
    ```

4. Run ChatDev

    ```bash
    python3 run.py --task "Design a game of tic-tac-toe." --name "TicTacToe"  --org "THUNLP" --config "Default"
    ```


https://github.com/OpenBMB/ChatDev/assets/7282984/462218bc-4b7e-4dc1-8e0f-6051e7d6d658


