### PR TITLE
fix: unexpected keyword arg refusal

### DIFF
--- a/camel/messages/chat_messages.py
+++ b/camel/messages/chat_messages.py
@@ -38,12 +38,14 @@ class ChatMessage(BaseMessage):
             for the message.
         role (str): The role of the message in OpenAI chat system.
         content (str): The content of the message. (default: :obj:`""`)
+        refusal (str): The refusal to build argument.
     """
     role_name: str
     role_type: RoleType
     meta_dict: Optional[Dict[str, str]]
     role: str
     content: str = ""
+    refusal: str = None
     if openai_new_api:
         function_call: Optional[FunctionCall] = None
         tool_calls: Optional[ChatCompletionMessageToolCall] = None
@@ -55,6 +57,7 @@ class ChatMessage(BaseMessage):
             meta_dict=self.meta_dict,
             role="user",
             content=self.content,
+            refusal=self.refusal,
         )
 
 
@@ -72,12 +75,14 @@ class AssistantChatMessage(ChatMessage):
         role (str): The role of the message in OpenAI chat system.
             (default: :obj:`"assistant"`)
         content (str): The content of the message. (default: :obj:`""`)
+        refusal (str): The refusal to build argument.
     """
     role_name: str
     role_type: RoleType = RoleType.ASSISTANT
     meta_dict: Optional[Dict[str, str]] = None
     role: str = "user"
     content: str = ""
+    refusal: str = None
 
 
 @dataclass
@@ -92,9 +97,11 @@ class UserChatMessage(ChatMessage):
         role (str): The role of the message in OpenAI chat system.
             (default: :obj:`"user"`)
         content (str): The content of the message. (default: :obj:`""`)
+        refusal (str): The refusal to build argument.
     """
     role_name: str
     role_type: RoleType = RoleType.USER
     meta_dict: Optional[Dict[str, str]] = None
     role: str = "user"
     content: str = ""
+    refusal: str = None


### PR DESCRIPTION
Added `refusal` argument to `ChatMessage` class.
Resolves Issue #413: https://github.com/OpenBMB/ChatDev/issues/413

Fixes the TypeError exception:

```
Traceback (most recent call last):
  File "/opt/anaconda3/envs/ChatDev_conda_env/lib/python3.9/site-packages/tenacity/__init__.py", line 382, in __call__
    result = fn(*args, **kwargs)
  File "/Users/jpmiller/Projects/ChatDev/camel/utils.py", line 154, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/jpmiller/Projects/ChatDev/camel/agents/chat_agent.py", line 243, in step
    output_messages = [
  File "/Users/jpmiller/Projects/ChatDev/camel/agents/chat_agent.py", line 244, in <listcomp>
    ChatMessage(role_name=self.role_name, role_type=self.role_type,
TypeError: __init__() got an unexpected keyword argument 'refusal'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jpmiller/Projects/ChatDev/run.py", line 134, in <module>
    chat_chain.execute_chain()
  File "/Users/jpmiller/Projects/ChatDev/chatdev/chat_chain.py", line 168, in execute_chain
    self.execute_step(phase_item)
  File "/Users/jpmiller/Projects/ChatDev/chatdev/chat_chain.py", line 138, in execute_step
    self.chat_env = self.phases[phase].execute(self.chat_env,
  File "/Users/jpmiller/Projects/ChatDev/chatdev/phase.py", line 295, in execute
    self.chatting(chat_env=chat_env,
  File "/Users/jpmiller/Projects/ChatDev/chatdev/utils.py", line 79, in wrapper
    return func(*args, **kwargs)
  File "/Users/jpmiller/Projects/ChatDev/chatdev/phase.py", line 133, in chatting
    assistant_response, user_response = role_play_session.step(input_user_msg, chat_turn_limit == 1)
  File "/Users/jpmiller/Projects/ChatDev/camel/agents/role_playing.py", line 247, in step
    assistant_response = self.assistant_agent.step(user_msg_rst)
  File "/opt/anaconda3/envs/ChatDev_conda_env/lib/python3.9/site-packages/tenacity/__init__.py", line 289, in wrapped_f
    return self(f, *args, **kw)
  File "/opt/anaconda3/envs/ChatDev_conda_env/lib/python3.9/site-packages/tenacity/__init__.py", line 379, in __call__
    do = self.iter(retry_state=retry_state)
  File "/opt/anaconda3/envs/ChatDev_conda_env/lib/python3.9/site-packages/tenacity/__init__.py", line 326, in iter
    raise retry_exc from fut.exception()
tenacity.RetryError: RetryError[<Future at 0x10c4feac0 state=finished raised TypeError>]
```