### PR TITLE
Add Gemini 1.5 Pro and Flash Support

### DIFF
--- a/camel/messages/base.py
+++ b/camel/messages/base.py
@@ -249,7 +249,7 @@ class BaseMessage:
             OpenAIMessage: The converted :obj:`OpenAIMessage` object.
         """
         role = role or self.role
-        if role not in {"system", "user", "assistant"}:
+        if role not in {"system", "user", "assistant", "model"}:
             raise ValueError(f"Unrecognized role: {role}")
         return {"role": role, "content": self.content}
 

--- a/camel/model_backend.py
+++ b/camel/model_backend.py
@@ -175,8 +175,7 @@ class GeminiModel(ModelBackend):
         num_prompt_tokens = model.count_tokens(string).total_tokens
         num_max_token_map = {
             "gemini-1.5-pro": 1000000,
-            "gemini-1.5-flash": 1000000,
-            "gemini-pro-vision": 12288,
+            "gemini-1.5-flash": 1000000
         }
         num_max_token = num_max_token_map[self.model_type.value]
         num_max_completion_tokens = num_max_token - num_prompt_tokens

--- a/camel/typing.py
+++ b/camel/typing.py
@@ -52,6 +52,8 @@ class ModelType(Enum):
     GPT_4_TURBO_V = "gpt-4-turbo"
     GPT_4O = "gpt-4o"
     GPT_4O_MINI = "gpt-4o-mini"
+    GEMINI_1_5_PRO="gemini-1.5-pro"
+    GEMINI_1_5_FLASH = "gemini-1.5-flash"
 
     STUB = "stub"
 

--- a/camel/utils.py
+++ b/camel/utils.py
@@ -91,7 +91,9 @@ def num_tokens_from_messages(
         ModelType.GPT_4_TURBO_V,
         ModelType.GPT_4O,
         ModelType.GPT_4O_MINI,
-        ModelType.STUB
+        ModelType.STUB,
+        ModelType.GEMINI_1_5_FLASH,
+        ModelType.GEMINI_1_5_PRO
     }:
         return count_tokens_openai_chat_models(messages, encoding)
     else:
@@ -130,6 +132,10 @@ def get_model_token_limit(model: ModelType) -> int:
         return 128000
     elif model == ModelType.GPT_4O_MINI:
         return 128000
+    elif model == ModelType.GEMINI_1_5_FLASH:
+        return 1000000
+    elif model == ModelType.GEMINI_1_5_PRO:
+        return 1000000
     else:
         raise ValueError("Unknown model type")
 
@@ -158,6 +164,8 @@ def openai_api_key_required(func: F) -> F:
             return func(self, *args, **kwargs)
         elif 'OPENAI_API_KEY' in os.environ:
             return func(self, *args, **kwargs)
+        elif 'GEMINI_API_KEY' in os.environ:
+            return func(self, *args, **kwargs);
         else:
             raise ValueError('OpenAI API key not found.')
 

--- a/camel/web_spider.py
+++ b/camel/web_spider.py
@@ -6,8 +6,20 @@ import wikipediaapi
 import os
 import time
 
-self_api_key = os.environ.get('OPENAI_API_KEY')
-BASE_URL = os.environ.get('BASE_URL')
+if 'OPENAI_API_KEY' in os.environ:
+    self_api_key = os.environ['OPENAI_API_KEY']
+else:
+    self_api_key = None
+    
+if 'BASE_URL' in os.environ:
+    BASE_URL = os.environ['BASE_URL']
+else:
+    BASE_URL = None
+
+if 'GEMINI_API_KEY' in os.environ:
+    self_api_key = os.environ['GEMINI_API_KEY']
+else:
+    self_api_key = None   
 
 if BASE_URL:
     client = openai.OpenAI(

--- a/ecl/embedding.py
+++ b/ecl/embedding.py
@@ -1,11 +1,20 @@
 import os
 import openai
 from openai import OpenAI
-OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
+if 'OPENAI_API_KEY' in os.environ:
+    OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
+else:
+    OPENAI_API_KEY = None
+    
 if 'BASE_URL' in os.environ:
     BASE_URL = os.environ['BASE_URL']
 else:
     BASE_URL = None
+
+if 'GEMINI_API_KEY' in os.environ:
+    GEMINI_API_KEY = os.environ['GEMINI_API_KEY']
+else:
+    GEMINI_API_KEY = None   
 import sys
 import time
 from tenacity import (

--- a/ecl/utils.py
+++ b/ecl/utils.py
@@ -16,11 +16,20 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential
 )
-OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
+if 'OPENAI_API_KEY' in os.environ:
+    OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
+else:
+    OPENAI_API_KEY = None
+    
 if 'BASE_URL' in os.environ:
     BASE_URL = os.environ['BASE_URL']
 else:
     BASE_URL = None
+
+if 'GEMINI_API_KEY' in os.environ:
+    GEMINI_API_KEY = os.environ['GEMINI_API_KEY']
+else:
+    GEMINI_API_KEY = None   
 
 def getFilesFromType(sourceDir, filetype):
     files = []

--- a/run.py
+++ b/run.py
@@ -97,6 +97,8 @@ args2type = {'GPT_3_5_TURBO': ModelType.GPT_3_5_TURBO,
             #  'GPT_4_TURBO_V': ModelType.GPT_4_TURBO_V
             'GPT_4O': ModelType.GPT_4O,
             'GPT_4O_MINI': ModelType.GPT_4O_MINI,
+            'GEMINI_1_5_FLASH': ModelType.GEMINI_1_5_FLASH,
+            'GEMINI_1_5_PRO': ModelType.GEMINI_1_5_PRO
              }
 if openai_new_api:
     args2type['GPT_3_5_TURBO'] = ModelType.GPT_3_5_TURBO_NEW


### PR DESCRIPTION
This PR adds support for two base models as a backend: `gemini-1.5-pro` and `gemini-1.5-flash` using Google's Generative AI library. These can be used with a free API key from [Google AI Studio](https://aistudio.google.com/). 

Can be run with:
`python run.py ... --model "GEMINI_1_5_FLASH"` or `python run.py ... --model "GEMINI_1_5_PRO"` 

One thing I'm unclear on:
Gemini returns its role as "model" instead of "assistant". Not sure if or how this messes with the code gen. You can see where I enable this role in `base.py`. Are there places where the role is super relevant and this should be updated for Gemini?