### PR TITLE
modify ecl/codes.py filename=self.main_script

### DIFF
--- a/ecl/codes.py
+++ b/ecl/codes.py
@@ -42,7 +42,7 @@ class Codes:
                 group1 = match.group(1)
                 filename = extract_filename_from_line(group1)
                 if "__main__" in code:
-                    filename = "main.py"
+                    filename = self.main_script
                 if filename == "":  # post-processing
                     filename = extract_filename_from_code(code)
                 assert filename != ""


### PR DESCRIPTION
 
modify: ecl/codes.py Codes class

Codes()._run_codes() use main_script as program entrance, if entrance script is not 'main_script', will not run _run_codes() completely, because the following code(will return with the first if):
`
def _run_codes(self) -> None:
    directory = os.path.abspath(self.directory)
    if self.main_script not in os.listdir(directory):
        return False, "{} Not Found".format(self.main_script)
`