### PR TITLE
refactor: add timeout and max_retries for OpenAI SDK v1.0 compatibility

### DIFF
--- a/camel/model_backend.py
+++ b/camel/model_backend.py
@@ -76,6 +76,8 @@ class OpenAIModel(ModelBackend):
                 client = openai.OpenAI(
                     api_key=OPENAI_API_KEY,
                     base_url=BASE_URL,
+                    timeout=60.0, # Adding a logical timeout for better reliability
+                    max_retries=3  # Standardizing retries
                 )
             else:
                 client = openai.OpenAI(

--- a/camel/web_spider.py
+++ b/camel/web_spider.py
@@ -13,6 +13,8 @@ if BASE_URL:
     client = openai.OpenAI(
         api_key=self_api_key,
         base_url=BASE_URL,
+        timeout=60.0, # Adding a logical timeout for better reliability
+        max_retries=3  # Standardizing retries
     )
 else:
     client = openai.OpenAI(

--- a/ecl/embedding.py
+++ b/ecl/embedding.py
@@ -33,6 +33,8 @@ class OpenAIEmbedding:
                 client = openai.OpenAI(
                     api_key=OPENAI_API_KEY,
                     base_url=BASE_URL,
+                    timeout=60.0, # Adding a logical timeout for better reliability
+                    max_retries=3  # Standardizing retries
                 )
             else:
                 client = openai.OpenAI(
@@ -59,6 +61,8 @@ class OpenAIEmbedding:
                 client = openai.OpenAI(
                     api_key=OPENAI_API_KEY,
                     base_url=BASE_URL,
+                    timeout=60.0, # Adding a logical timeout for better reliability
+                    max_retries=3  # Standardizing retries
                 )
             else:
                 client = openai.OpenAI(

--- a/ecl/utils.py
+++ b/ecl/utils.py
@@ -116,6 +116,8 @@ class OpenAIModel(ModelBackend):
             client = openai.OpenAI(
                 api_key=OPENAI_API_KEY,
                 base_url=BASE_URL,
+                timeout=60.0, # Adding a logical timeout for better reliability
+                max_retries=3  # Standardizing retries
             )
         else:
             client = openai.OpenAI(


### PR DESCRIPTION
Hi @maintainer, thank you for the feedback.

I have updated the PR to target the chatdev1.0 branch. Since the proxies argument was already removed in this branch, I have implemented the following logical changes:

Added timeout=60.0 and max_retries=3 to the OpenAI client initialization to improve reliability and handle network latencies better in the new SDK.

Reverted the non-functional comment changes in embedding.py to keep the codebase clean.

I believe this makes the client more robust for users on the latest OpenAI SDK. Ready for your review