### PR TITLE
fix: missing system dependencies install in gha

### DIFF
--- a/.github/workflows/validate-yamls.yml
+++ b/.github/workflows/validate-yamls.yml
@@ -20,8 +20,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  validate:
-    name: Validate YAML Configuration Files
+  validate-yamls:
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Small changes to update GHA with `sudo apt-get install -y libcairo2-dev pkg-config` for `pycairo` package