### PR TITLE
Add Spring Festival demo workflows (text/image EN version and 3D)

### DIFF
--- a/yaml_instance/spring_3d.yaml
+++ b/yaml_instance/spring_3d.yaml
@@ -1,0 +1,284 @@
+version: 0.4.0
+vars: {}
+graph:
+  id: spring_3d
+  description: "Stable rich 3D pipeline (code-only): spec -> plan -> bpy script -> static review -> patch -> final package. No tool calls."
+  log_level: INFO
+  is_majority_voting: false
+  start:
+    - Product Manager
+
+  nodes:
+    - id: Product Manager
+      type: agent
+      description: "Convert 1-line idea into a quantified 3D Design Spec with hard complexity targets."
+      context_window: 0
+      config:
+        provider: openai
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        name: gpt-4o
+        role: |
+          # Role
+          You are a professional **3D Technical Product Manager**.
+
+          # Goal
+          Convert the user's one-sentence idea into a detailed, quantified **3D Design Spec** executable by Blender Python (bpy).
+
+          # HARD COMPLEXITY REQUIREMENTS (must satisfy)
+          - Scene must include at least **12 distinct object types** (not counting duplicates).
+          - Total object count (including duplicates/instances) must be **>= 40**.
+          - Must include: ground/terrain, main structure(s), props, decorations, food/tableware, lighting fixtures, and background elements.
+          - Must specify at least **6 materials** with procedural node hints (no flat colors).
+          - Must specify lighting with **3-point lighting** (key/fill/rim) or a justified alternative.
+          - Must include camera composition target (rule of thirds / centered symmetry / isometric).
+
+          # Output Format (STRICT Markdown)
+          ## 1. Scene Overview
+          * **Theme**:
+          * **Style**: (Low Poly / Voxel / Semi-realistic / Realistic)
+          * **Scale**: (e.g., 30m x 30m)
+          * **Mood**:
+          * **Composition**: (how camera frames the scene)
+          * **Object Complexity Target**: (>=12 types, >=40 total)
+
+          ## 2. Object List (Quantified)
+          For EACH object type:
+          * **Name**:
+          * **Quantity**:
+          * **Dimensions**: (L x W x H meters)
+          * **Geometry**: (primitive composition)
+          * **Material Look**: (procedural node idea, at least 2-color variation)
+          * **Placement**: (coordinate range and logic)
+
+          ## 3. Lighting & Camera
+          * **Key Light**:
+          * **Fill Light**:
+          * **Rim Light**:
+          * **Optional Practical Lights**: (lantern glow, etc.)
+          * **Camera**: (lens, position, target)
+
+          # Constraints
+          - Do NOT ask user for more info; improvise missing details.
+          - Keep geometry code-friendly and physically plausible.
+        params:
+          temperature: 0.6
+          max_tokens: 1800
+
+    - id: Planner
+      type: agent
+      description: "Deconstruct the spec into a step-by-step plan that guarantees rich scene building."
+      context_window: 0
+      config:
+        provider: openai
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        name: gpt-4o
+        role: |
+          # Role
+          You are the **Technical Planner**.
+
+          # Input
+          A 3D Design Spec with quantified objects.
+
+          # Goal
+          Produce a step-by-step plan that guarantees the Architect can generate a rich scene.
+
+          # HARD REQUIREMENTS
+          - Plan must contain **>= 12 build steps**, each step builds one object type (and applies its material).
+          - Each step must include: dimensions, count, coordinate ranges, and material recipe name.
+          - Include at least **2 scatter steps** (decorations/props).
+          - Include a final step that sets camera, lighting, render settings, and a "scene summary print".
+
+          # Output Format
+          Analysis:
+          <brief risks & ordering>
+
+          Plan:
+          1. [Environment]: ...
+          2. [Main Structure]: ...
+          3. [Details]: ...
+          4. [Props]: ...
+          5. [Food/Tableware]: ...
+          6. [Decorations]: ...
+          7. [Scatter A]: ...
+          8. [Scatter B]: ...
+          ...
+          12. [Finalize]: ...
+        params:
+          temperature: 0.5
+          max_tokens: 1600
+
+    - id: Procedural Architect
+      type: agent
+      description: "Write a rich Blender bpy script (TEXT ONLY). No tool calls."
+      context_window: 10
+      config:
+        provider: openai
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        name: gpt-4o
+        role: |
+          # Identity
+          You are a **Procedural Architect** (Blender bpy expert).
+
+          # IMPORTANT: NO TOOL CALLS
+          Output ONLY ONE Python code block (```python ...```).
+          No extra text outside code.
+
+          # QUALITY BAR (must satisfy)
+          - Create **>= 12 distinct object types** and **>= 40 total objects** (instances allowed).
+          - Must create a **Ground/Terrain** and **background elements** (e.g., walls, fence, trees, skyline, distant lights).
+          - Must build a **main structure** (gate/door/frame) with layered parts.
+          - Must include a **table + 6+ tableware items** and **>= 20 dumplings** with scatter.
+          - Must include **decorations**: couplets, lanterns, knots, banners, string lights, fireworks props, etc.
+          - Must set up **Key/Fill/Rim** lights + optional emissive lantern material.
+          - Must set camera with a target empty and use a Track To constraint.
+
+          # ENGINEERING RULES
+          - Prefer bpy.data mesh creation + modifiers; avoid edit-mode toggling.
+          - Avoid context-fragile ops when possible; if using bpy.ops, do it consistently in Object Mode.
+          - Use Collections: Environment, Structure, Props, LightsCam.
+          - Use naming: ENV_, STR_, PROP_, LGT_, CAM_.
+
+          # MATERIAL RULES (MANDATORY)
+          - NO flat Base Color. Use Noise Texture + ColorRamp to mix at least 2 colors.
+          - Create a small material library:
+            - make_noise_material(name, color_a, color_b, roughness_range)
+            - make_emissive_material(name, color, strength)
+          - Assign materials to ALL meshes.
+
+          # REQUIRED SCRIPT STRUCTURE
+          1) imports + seed
+          2) reset_scene() (delete objects, purge orphans safely)
+          3) collection setup
+          4) material library functions
+          5) geometry helper functions (add_cube, add_cylinder, add_sphere, add_plane)
+          6) build scene following the Plan
+          7) lights + camera + render settings
+          8) final summary prints (object counts by collection)
+
+          Output: ONE python code block only.
+        params:
+          temperature: 0.4
+          max_tokens: 2600
+
+    - id: Reviewer
+      type: agent
+      description: "Static review focused on richness, completeness, and likely runtime errors."
+      context_window: 10
+      config:
+        provider: openai
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        name: gpt-4o
+        role: |
+          You are a **Technical Supervisor**.
+
+          Do a STATIC review. Focus on:
+          - Complexity target met (>=12 types, >=40 objects)?
+          - 6+ procedural materials applied to all meshes?
+          - Key/Fill/Rim lights present and camera set with a target?
+          - Any obvious runtime errors or incomplete code?
+
+          Output STRICT:
+          NEED_FIX: <YES|NO>
+          TOP_BUGS:
+          - ...
+          PATCH_GUIDE:
+          - ...
+        params:
+          temperature: 0.3
+          max_tokens: 900
+
+    - id: Patch_Architect
+      type: agent
+      description: "Always output a final runnable script; expand if too simple and fix likely errors."
+      context_window: 10
+      config:
+        provider: openai
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        name: gpt-4o
+        role: |
+          You receive: Spec + Plan + Script + Reviewer notes.
+
+          ALWAYS output ONE final Blender script (single code block).
+          If NEED_FIX is YES OR script is too simple, expand it to meet:
+          - >=12 object types, >=40 objects
+          - Ground + background
+          - Tableware + >=20 dumplings
+          - 6+ procedural materials
+          - Key/Fill/Rim lights + camera target
+
+          Also ensure:
+          - No incomplete trailing lines
+          - No missing material assignments
+          - Avoid edit-mode toggling
+          - Run-safe in Blender 3.x+ as a single script
+
+          Output ONLY ONE python code block. No extra text.
+        params:
+          temperature: 0.35
+          max_tokens: 2600
+
+    - id: Final_Package
+      type: agent
+      description: "Publish-ready package (spec+plan+final script+run guide)."
+      context_window: 10
+      config:
+        provider: openai
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        name: gpt-4o
+        role: |
+          Output Markdown with:
+          # 3D Case Summary (1 paragraph)
+          # Design Spec (verbatim)
+          # Execution Plan (verbatim)
+          # Blender Script (final code block)
+          # How to Run in Blender (5 steps)
+          # Render Tips (5 bullets)
+          # Common Errors & Fixes (5 bullets)
+        params:
+          temperature: 0.4
+          max_tokens: 1800
+
+  edges:
+    - from: Product Manager
+      to: Planner
+      trigger: true
+      condition: "true"
+      carry_data: true
+      keep_message: false
+
+    - from: Planner
+      to: Procedural Architect
+      trigger: true
+      condition: "true"
+      carry_data: true
+      keep_message: true
+
+    - from: Procedural Architect
+      to: Reviewer
+      trigger: true
+      condition: "true"
+      carry_data: true
+      keep_message: true
+
+    - from: Reviewer
+      to: Patch_Architect
+      trigger: true
+      condition: "true"
+      carry_data: true
+      keep_message: true
+
+    - from: Patch_Architect
+      to: Final_Package
+      trigger: true
+      condition: "true"
+      carry_data: true
+      keep_message: true
+
+  end:
+    - Final_Package

--- a/yaml_instance/spring_text_image.yaml
+++ b/yaml_instance/spring_text_image.yaml
@@ -1,0 +1,244 @@
+version: 0.4.0
+vars: {}
+graph:
+  id: spring_text_image
+  description: 'Launch-driven Spring Festival content factory: plan -> parallel gen -> edit -> human review -> revise (gpt-4o).'
+  is_majority_voting: false
+  start:
+    - Planner
+  nodes:
+    - id: Planner
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          你是春节新媒体策划。
+          用户在 Launch 时输入的内容，就是本次任务的唯一要求。
+          请输出创作 Brief（Markdown），必须包含：
+          ## 受众
+          ## 核心传播点（3条）
+          ## 风格与禁忌
+          ## 必须出现的元素
+          ## 可选创意梗（2条）
+          ## 写作任务总结（一句话）
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.6
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+    - id: Copywriter
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          你是官号文案作者。根据 Brief 输出一篇可直接发布的春节推文（Markdown）。
+          要求：
+          - 标题 1 个（吸睛但不标题党）
+          - 正文 4-6 段（段落短，节奏快）
+          - 至少 3 个可传播金句（加粗）
+          - 结尾 2 条互动引导（评论区话题/投票/分享）
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.7
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+    - id: Blessing
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          你是春节祝福语写手。根据 Brief 输出 12 条短祝福（Markdown 列表）：
+          - 温情 4 条 / 幽默 4 条 / 国风 4 条
+          - 每条不超过 18 字
+          - 不要重复表达
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.85
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+    - id: Storyteller
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          你是短故事写手。根据 Brief 写一个 300-500 字春节小故事（Markdown）。
+          要求：有一个记忆点（反转/细节/一句金句）；结尾落到团圆/祝福/新开始。
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.85
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+    - id: PosterPrompt
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          根据“最终发布包”，生成海报用的图像生成提示词（prompt pack），要求：
+          - 3 个风格方向（国风/现代极简/手绘插画）
+          - 每个方向给：正向提示词、负向提示词、画幅比例建议、主标题/副标题排版建议
+          输出 Markdown。
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.6
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+    - id: Editor1
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          你是总编辑。你会收到：Brief + 推文 + 祝福语 + 小故事。
+          请整合为一个“官号发布包（初稿）”（Markdown），结构固定为：
+          # 标题候选（3个）
+          # 正文终稿（1篇）
+          # 海报短句（从祝福语精选 6 条）
+          # 配图/排版建议（5条）
+          # 评论区话题（3条）
+          语言风格统一，内容可直接复制发布。
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.5
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 10
+      log_output: true
+    - id: HumanReview
+      type: human
+      config:
+        description: |
+          请审核“官号发布包（初稿）”：
+          - 若满意请输入：ACCEPT（流程结束）
+          - 否则请输入修改意见（越具体越好）
+      description: ''
+      context_window: 10
+      log_output: true
+    - id: Editor2
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          你是二次润色编辑。你会收到“发布包初稿 + 人工修改意见”。
+          请输出修改后的最终发布包（Markdown），要求：
+          - 完整保留发布包的结构（标题候选/正文终稿/海报短句/配图建议/评论区话题）
+          - 修改意见逐条落实
+          - 语言风格统一、可直接发布
+          - 若发现初稿结构缺失或不一致，需要补齐并修正
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.45
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 10
+      log_output: true
+    - id: ImageGen
+      type: agent
+      config:
+        name: gemini-2.5-flash-image-preview
+        provider: openai
+        role: |
+          根据输入的“海报提示词方案”，对于每一个方案生成 1 张春节主题海报图。
+          注意海报中如果涉及文字，务必保证文字准确性，否则不要使用文字。
+          若支持比例参数，请优先按建议画幅生成；否则生成 1:1。
+          输出直接给出生成结果（按系统返回格式）。
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params: {}
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+        input_mode: messages
+      description: ''
+      context_window: 0
+      log_output: true
+  edges:
+    - from: Planner
+      to: Copywriter
+    - from: Planner
+      to: Blessing
+    - from: Planner
+      to: Storyteller
+    - from: Planner
+      to: Editor1
+    - from: Copywriter
+      to: Editor1
+    - from: Blessing
+      to: Editor1
+    - from: Storyteller
+      to: Editor1
+    - from: Editor2
+      to: PosterPrompt
+    - from: PosterPrompt
+      to: ImageGen
+    - from: HumanReview
+      to: Editor2
+      trigger: true
+      condition:
+        type: keyword
+        config:
+          any: []
+          none:
+            - ACCEPT
+          regex: []
+          case_sensitive: true
+      carry_data: true
+      keep_message: true
+      clear_context: true
+      clear_kept_context: false
+      process: null
+      dynamic: null
+    - from: Editor1
+      to: HumanReview
+      trigger: true
+      condition: null
+      carry_data: true
+      keep_message: true
+      clear_context: true
+      clear_kept_context: false
+      process: null
+      dynamic: null

--- a/yaml_instance/spring_text_image_EN.yaml
+++ b/yaml_instance/spring_text_image_EN.yaml
@@ -1,0 +1,269 @@
+version: 0.4.0
+vars: {}
+graph:
+  id: spring_text_image_EN
+  description: 'Launch-driven Spring Festival content factory: plan -> parallel gen -> edit -> human review -> revise (gpt-4o).'
+  is_majority_voting: false
+  start:
+    - Planner
+  nodes:
+    - id: Planner
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          You are a Spring Festival social media strategist.
+          The content entered at Launch is the only requirement for this task.
+          Please output a creation Brief (Markdown) that MUST include:
+          ## Target Audience
+          ## Core Communication Points (3)
+          ## Style & Taboos
+          ## Required Elements
+          ## Optional Creative Hooks (2)
+          ## One-Sentence Writing Task Summary
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.6
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+
+    - id: Copywriter
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          You are the official account copywriter.
+          Based on the Brief, produce a Spring Festival post ready for publication (Markdown).
+          Requirements:
+          - 1 headline (eye-catching but not clickbait)
+          - 4–6 short paragraphs (fast rhythm, concise)
+          - At least 3 highly shareable punchlines (in **bold**)
+          - 2 interaction prompts at the end (e.g., comment topic / poll / share CTA)
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.7
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+
+    - id: Blessing
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          You are a Spring Festival greeting writer.
+          Based on the Brief, generate 12 short greetings (Markdown list):
+          - 4 warm
+          - 4 humorous
+          - 4 traditional/Chinese-style
+          - Each greeting must be no more than 18 words
+          - Avoid repetitive expressions
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.85
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+
+    - id: Storyteller
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          You are a short story writer.
+          Based on the Brief, write a 300–500 word Spring Festival short story (Markdown).
+          Requirements:
+          - Include one memorable element (twist / detail / punchline)
+          - End with reunion, blessing, or a sense of new beginning
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.85
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+
+    - id: PosterPrompt
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          Based on the "Final Publication Package", generate a prompt pack for image generation.
+          Requirements:
+          - 3 style directions (Traditional Chinese / Modern Minimalist / Hand-drawn Illustration)
+          - For each direction provide:
+            - Positive prompt
+            - Negative prompt
+            - Suggested aspect ratio
+            - Main title / subtitle layout suggestions
+          Output in Markdown.
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.6
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 0
+      log_output: true
+
+    - id: Editor1
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          You are the chief editor.
+          You will receive: Brief + Post + Greetings + Short Story.
+          Please integrate them into an "Official Publication Package (Draft)" (Markdown),
+          with the following fixed structure:
+          # Headline Options (3)
+          # Final Main Post (1)
+          # Poster Short Lines (Select 6 from the greetings)
+          # Visual/Layout Suggestions (5)
+          # Comment Section Topics (3)
+          Ensure unified tone and make it directly publishable.
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.5
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 10
+      log_output: true
+
+    - id: HumanReview
+      type: human
+      config:
+        description: |
+          Please review the "Official Publication Package (Draft)":
+          - If satisfied, enter: ACCEPT (the workflow will end)
+          - Otherwise, provide revision feedback (be as specific as possible)
+      description: ''
+      context_window: 10
+      log_output: true
+
+    - id: Editor2
+      type: agent
+      config:
+        name: gpt-4o
+        provider: openai
+        role: |
+          You are the second-round polishing editor.
+          You will receive the draft package + human revision feedback.
+          Please output the revised final publication package (Markdown).
+          Requirements:
+          - Fully preserve the structure (Headline Options / Final Post / Poster Lines / Visual Suggestions / Comment Topics)
+          - Address each revision point explicitly
+          - Ensure consistent tone and publish-ready quality
+          - If structure is missing or inconsistent, fix and complete it
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params:
+          temperature: 0.45
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+      description: ''
+      context_window: 10
+      log_output: true
+
+    - id: ImageGen
+      type: agent
+      config:
+        name: gemini-2.5-flash-image-preview
+        provider: openai
+        role: |
+          Based on the provided poster prompt schemes, generate 1 Spring Festival themed poster image for each scheme.
+          If the poster involves text, ensure text accuracy. If text accuracy cannot be guaranteed, avoid including text.
+          If aspect ratio parameters are supported, prioritize the suggested ratio; otherwise use 1:1.
+          Output the result directly in the system-returned format.
+        base_url: ${BASE_URL}
+        api_key: ${API_KEY}
+        params: {}
+        tooling: []
+        thinking: null
+        memories: []
+        retry: null
+        input_mode: messages
+      description: ''
+      context_window: 0
+      log_output: true
+
+  edges:
+    - from: Planner
+      to: Copywriter
+    - from: Planner
+      to: Blessing
+    - from: Planner
+      to: Storyteller
+    - from: Planner
+      to: Editor1
+    - from: Copywriter
+      to: Editor1
+    - from: Blessing
+      to: Editor1
+    - from: Storyteller
+      to: Editor1
+    - from: Editor2
+      to: PosterPrompt
+    - from: PosterPrompt
+      to: ImageGen
+    - from: HumanReview
+      to: Editor2
+      trigger: true
+      condition:
+        type: keyword
+        config:
+          any: []
+          none:
+            - ACCEPT
+          regex: []
+          case_sensitive: true
+      carry_data: true
+      keep_message: true
+      clear_context: true
+      clear_kept_context: false
+      process: null
+      dynamic: null
+    - from: Editor1
+      to: HumanReview
+      trigger: true
+      condition: null
+      carry_data: true
+      keep_message: true
+      clear_context: true
+      clear_kept_context: false
+      process: null
+      dynamic: null


### PR DESCRIPTION
Add Spring Festival workflows: spring_text_image, spring_text_image_EN, and spring_3d 

spring_text_image – Chinese prompt version of a multi-agent content pipeline (planner → copywriter → editor → poster generation).

spring_text_image_EN – English prompt version of the same workflow structure, adapted for broader international usage.

spring_3d – A simplified 3D scene generation workflow that outputs Blender Python scripts for Spring Festival themed scenes.

These workflows are designed as seasonal demo cases and can serve as references for text, image, and 3D content generation pipelines.