### PR TITLE
Fix typo: pricess to process

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See our paper in [Multi-Agent Collaboration via Evolving Orchestration](https://
   <img src='./assets/macnet.png' width=500>
   </p>
 
-• May 07, 2024, we introduced "Iterative Experience Refinement" (IER), a novel method where instructor and assistant agents enhance shortcut-oriented experiences to efficiently adapt to new tasks. This approach encompasses experience acquisition, utilization, propagation and elimination across a series of tasks and making the pricess shorter and efficient. Our preprint paper is available at https://arxiv.org/abs/2405.04219, and this technique will soon be incorporated into ChatDev.
+• May 07, 2024, we introduced "Iterative Experience Refinement" (IER), a novel method where instructor and assistant agents enhance shortcut-oriented experiences to efficiently adapt to new tasks. This approach encompasses experience acquisition, utilization, propagation and elimination across a series of tasks and making the process shorter and efficient. Our preprint paper is available at https://arxiv.org/abs/2405.04219, and this technique will soon be incorporated into ChatDev.
   <p align="center">
   <img src='./assets/ier.png' width=220>
   </p>


### PR DESCRIPTION
Fixed typo in README where 'pricess' was written instead of 'process'