### PR TITLE
fix: use RichTooltip for help icons in Safari/Edge

### DIFF
--- a/frontend/src/components/DynamicFormField.vue
+++ b/frontend/src/components/DynamicFormField.vue
@@ -5,13 +5,13 @@
         <label>
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <div class="child-node-container">
           <div class="child-node-controls">
@@ -120,13 +120,13 @@
         <label>
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <div class="child-node-container">
           <div class="child-node-controls">
@@ -232,13 +232,13 @@
         <label :for="`${modalId}-${field.name}`">
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <div class="custom-select-wrapper" :class="{ 'select-disabled': isReadOnly }">
           <input
@@ -291,13 +291,13 @@
         <label>
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <div class="multi-select-options">
           <label
@@ -328,13 +328,13 @@
           <label :for="`${modalId}-${field.name}`" class="switch-label-text">
             {{ field.displayName || field.name }}
             <span v-if="field.required" class="required-asterisk">*</span>
-            <span
+            <RichTooltip
               v-if="field.description"
-              class="help-icon"
-              :title="field.description"
+              :content="{ description: field.description }"
+              placement="top"
             >
-              ?
-            </span>
+              <span class="help-icon" tabindex="0">?</span>
+            </RichTooltip>
           </label>
           <label class="switch-container">
             <input
@@ -354,13 +354,13 @@
         <label :for="`${modalId}-${field.name}`">
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <input
           :id="`${modalId}-${field.name}`"
@@ -378,13 +378,13 @@
         <label :for="`${modalId}-${field.name}`">
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <textarea
           :id="`${modalId}-${field.name}`"
@@ -402,13 +402,13 @@
         <label :for="`${modalId}-${field.name}`">
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <input
           :id="`${modalId}-${field.name}`"
@@ -427,13 +427,13 @@
         <label :for="`${modalId}-${field.name}`">
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <input
           :id="`${modalId}-${field.name}`"
@@ -452,13 +452,13 @@
         <label>
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <div class="vars-container">
           <button @click="$emit('open-var-modal', field.name)" class="add-var-button">
@@ -507,13 +507,13 @@
         <label>
           {{ field.displayName || field.name }}
           <span v-if="field.required" class="required-asterisk">*</span>
-          <span
+          <RichTooltip
             v-if="field.description"
-            class="help-icon"
-            :title="field.description"
+            :content="{ description: field.description }"
+            placement="top"
           >
-            ?
-          </span>
+            <span class="help-icon" tabindex="0">?</span>
+          </RichTooltip>
         </label>
         <div class="list-container">
           <button @click="$emit('open-list-item-modal', field.name)" class="add-list-button">
@@ -556,6 +556,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import RichTooltip from './RichTooltip.vue'
 
 const props = defineProps({
   field: {


### PR DESCRIPTION
## Problem

Help icon tooltips (the **?** icons next to form field labels) do not appear in Safari and Edge on macOS, as reported in #538.

## Root Cause

The help icons in `DynamicFormField.vue` used native HTML `title` attributes for tooltips. The native `title` attribute has inconsistent behavior across browsers — particularly in Safari and Edge, where:
- Tooltips require a long hover delay (~2s) before appearing
- They don't respond to click/tap interactions
- They have no keyboard accessibility

## Solution

Replaced all 11 native `title`-based help icons with the existing `RichTooltip` component, which already provides:
- Consistent cross-browser tooltip rendering
- Hover activation with configurable delay
- Keyboard accessibility (Space/Enter to toggle, Escape to dismiss)
- Rich content support (title, description, examples, learn more links)
- Proper positioning with viewport boundary detection

## Changes

- **`frontend/src/components/DynamicFormField.vue`**: Wrapped all help icon `<span>` elements with `<RichTooltip>` and added `tabindex="0"` for keyboard focus. Imported the `RichTooltip` component.

## Testing

- `vite build` passes successfully
- Pre-existing eslint warnings (unrelated `vue/no-mutating-props`) remain unchanged
- No new warnings or errors introduced

Fixes #538