### PR TITLE
Feat: add persistent chat panel with fullscreen toggle

### DIFF
--- a/frontend/src/pages/LaunchView.vue
+++ b/frontend/src/pages/LaunchView.vue
@@ -2489,6 +2489,8 @@ watch(
   font-size: 13px;
   font-weight: 500;
   text-align: center;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .chat-notification-warning .notification-content {
@@ -2503,9 +2505,6 @@ watch(
 .chat-notification-error .notification-content {
   background: rgba(255, 82, 82, 0.12);
   border-color: rgba(255, 82, 82, 0.4);
-}
-
-.chat-notification-error .notification-content {
   color: #ffcccc;
 }
 


### PR DESCRIPTION
### Context
Sometimes it is a bit hard to visualize the real-time changes between Chat and Graph-based UI.

### What's changing
- Convert chat from tab-based to persistent collapsible overlay panel
- Chat panel visible alongside Graph view as a side overlay
- Toggle button (chevron) to collapse/expand the overlay panel
- 'Chat' in view toggle activates full-screen chat mode filling left panel
- 'Graph' in view toggle shows graph with chat as overlay
- isChatPanelOpen state preserved across mode switches
- Default viewMode is 'chat' (full-screen on load)

![chatdev-toggle-chat-panel](https://github.com/user-attachments/assets/81989c15-d31d-42d8-a1f8-2cd469422806)

