### PR TITLE
fix: Fix what the navigation hide interaction affects all pages

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -61,13 +61,21 @@ const handleScroll = (e) => {
     lastScrollY = currentScrollY <= 0 ? 0 : currentScrollY;
 }
 
-onMounted(() => {
-    // Listen to scroll events during the capture phase to track child scrolling (like TutorialView)
-    window.addEventListener('scroll', handleScroll, true);
-})
+const toggleScrollListener = (shouldListen) => {
+    if (shouldListen) {
+        window.addEventListener('scroll', handleScroll, true);
+    } else {
+        window.removeEventListener('scroll', handleScroll, true);
+        isHidden.value = false; // Reset state when leaving
+    }
+}
+
+watch(() => route.path, () => {
+    toggleScrollListener(!!route.meta.hideNavOnScroll);
+}, { immediate: true }) // immediate: true runs this once on mount
 
 onUnmounted(() => {
-    window.removeEventListener('scroll', handleScroll, true);
+    toggleScrollListener(false);
     document.body.classList.remove('nav-hidden');
 })
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -7,7 +7,8 @@ const routes = [
     },
     {
         path: '/tutorial',
-        component: () => import('../pages/TutorialView.vue')
+        component: () => import('../pages/TutorialView.vue'),
+        meta: { hideNavOnScroll: true }
     },
     {
         path: '/launch',


### PR DESCRIPTION
## Related PR

#576 

## Description

This PR addresses an issue where the sidebar's auto-hide feature (on scroll), introduced in a previous update, was globally affecting pages beyond the `Tutorial` screen. This led to unintended layout shifts, such as unnecessary margins on other pages.

<img width="2179" height="1053" alt="workflow-page" src="https://github.com/user-attachments/assets/02132f5e-09e8-473d-b444-900af6337478" />

## Technical Considerations & Decision Making

I evaluated two primary approaches to resolve this:

1. **Option 1: Hardcoding the hide logic for the Tutorial page only.**
    - **Pros:** Quickest implementation.
    - **Cons:** High coupling. Any future pages requiring the same interaction would require manual internal component modifications, hindering scalability.

2. **Option 2: Enabling the Sidebar component to dynamically determine behavior based on route metadata.**
    - **Decision:** I chose this approach for long-term scalability. By leveraging route meta fields, the `Sidebar` can independently decide whether to activate the scroll-hide logic based on the current context.

## Changes

<img width="2178" height="1053" alt="changed" src="https://github.com/user-attachments/assets/08ed496a-6ae8-4601-9171-04ad21f48e74" />

- **Utilizing Vue Router Meta Fields**:
    - Added `meta: { hideNavOnScroll: true }` to the `/tutorial` route in `router/index.js`.
    - This ensures **extensibility**; if other pages need this interaction in the future, it can be enabled simply by adding a single line to the router configuration.

- **Performance Optimization (Dynamic Event Listener Allocation)**:
    - Removed the global scroll listener (`handleScroll`) that was previously attached upon the Sidebar mounting to prevent unnecessary computation and potential memory leaks.
    - Implemented a router `watch` to check the `meta.hideNavOnScroll` value only once during route transitions.
    - The scroll listener is now **dynamically attached only when entering designated pages** and is immediately cleaned up (`removeEventListener`) when navigating away to other pages.