### PR TITLE
fix(server): scope `--reload` watching to source dirs (#569)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -136,7 +136,7 @@ make dev
     # 从项目根目录运行
     uv run python server_main.py --port 6400 --reload
     ```
-    > 若输出文件（如 GameDev）触发重启导致任务中断、进度丢失，请去掉 `--reload`。
+    > `--reload` 仅监听服务端 Python 源代码目录，`WareHouse/` 下的智能体生成文件不会再触发重启。可通过 `--reload-dir` / `--reload-exclude`（可多次指定）自定义。
 
 2.  **启动前端**：
     ```bash

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ make dev
     # Run from the project root
     uv run python server_main.py --port 6400 --reload
     ```
-    > Remove `--reload` if output files (e.g., GameDev) trigger restarts, which interrupts tasks and loses progress.
+    > `--reload` watches the server's Python source folders only; agent-generated files under `WareHouse/` no longer trigger restarts. Pass `--reload-dir` or `--reload-exclude` (repeatable) to customise.
 
 2.  **Start Frontend**:
     ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ faiss-cpu
 fastapi==0.124.0
 click>=8.1.8,<8.3
 uvicorn
+watchfiles
 websockets
 wsproto
 pydantic==2.12.5

--- a/server_main.py
+++ b/server_main.py
@@ -26,16 +26,33 @@ RELOAD_SOURCE_DIRS = [
     "workflow",
 ]
 
-# Glob patterns excluded from reload watching. Only has effect when
-# ``watchfiles`` is installed (StatReload ignores these patterns), but
-# matches .gitignore intent as a second line of defence.
+# Directory names whose contents must never trigger a reload. These are
+# expanded into multi-depth glob patterns below so nested files (e.g.
+# ``WareHouse/demo/foo.py``) are also excluded: uvicorn applies these via
+# ``Path.match``, which on Python < 3.13 does not understand ``**`` and
+# matches a pattern of N components only against the last N path parts.
+_RELOAD_EXCLUDE_DIRS = ("WareHouse", "logs", "data", "temp", "node_modules")
+_RELOAD_EXCLUDE_MAX_DEPTH = 10
+
+# Glob patterns excluded from reload watching. Only honoured when
+# ``watchfiles`` is installed; StatReload (the pure-Python fallback that
+# ships with uvicorn core) ignores exclude patterns entirely, so the
+# primary defence is the reload_dirs restriction to RELOAD_SOURCE_DIRS.
 RELOAD_EXCLUDES = [
-    "WareHouse/*",
-    "logs/*",
-    "data/*",
-    "temp/*",
-    "node_modules/*",
+    f"{d}{'/*' * (depth + 1)}"
+    for d in _RELOAD_EXCLUDE_DIRS
+    for depth in range(_RELOAD_EXCLUDE_MAX_DEPTH)
 ]
+
+
+def _watchfiles_available() -> bool:
+    """Return ``True`` when the ``watchfiles`` package is importable.
+
+    Split out so tests can patch it without touching ``sys.modules``.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("watchfiles") is not None
 
 
 def build_reload_kwargs(args: argparse.Namespace) -> dict:
@@ -126,6 +143,14 @@ def main():
 
     logger = logging.getLogger(__name__)
     logger.info(f"Starting DevAll Workflow Server on {args.host}:{args.port}")
+
+    if args.reload and not _watchfiles_available():
+        logger.warning(
+            "--reload is active but 'watchfiles' is not installed; uvicorn will "
+            "fall back to StatReload, which ignores --reload-exclude patterns "
+            "(including the WareHouse/ defaults). Install watchfiles (or "
+            "`pip install uvicorn[standard]`) to enable exclude filtering."
+        )
 
     # Launch the server
     uvicorn.run(

--- a/server_main.py
+++ b/server_main.py
@@ -9,9 +9,50 @@ from server.app import app
 ensure_schema_registry_populated()
 
 
-def main():
-    import uvicorn
+# Directories containing the server's Python sources. When --reload is
+# enabled, only these are watched so that agent-generated files under
+# WareHouse/, logs/, etc. never trigger a StatReload restart mid-workflow
+# (issue #569).
+RELOAD_SOURCE_DIRS = [
+    "check",
+    "entity",
+    "functions",
+    "mcp_example",
+    "runtime",
+    "schema_registry",
+    "server",
+    "tools",
+    "utils",
+    "workflow",
+]
 
+# Glob patterns excluded from reload watching. Only has effect when
+# ``watchfiles`` is installed (StatReload ignores these patterns), but
+# matches .gitignore intent as a second line of defence.
+RELOAD_EXCLUDES = [
+    "WareHouse/*",
+    "logs/*",
+    "data/*",
+    "temp/*",
+    "node_modules/*",
+]
+
+
+def build_reload_kwargs(args: argparse.Namespace) -> dict:
+    """Build the reload-related kwargs passed to ``uvicorn.run``.
+
+    Extracted so the configuration is unit-testable without spinning up
+    a real server. When ``--reload`` is off the return value is empty.
+    """
+    if not args.reload:
+        return {}
+    return {
+        "reload_dirs": list(args.reload_dir) if args.reload_dir else list(RELOAD_SOURCE_DIRS),
+        "reload_excludes": list(args.reload_exclude) if args.reload_exclude else list(RELOAD_EXCLUDES),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DevAll Workflow Server")
     parser.add_argument(
         "--host",
@@ -36,17 +77,43 @@ def main():
         action="store_true",
         help="Enable auto-reload for development"
     )
-    
-    args = parser.parse_args()
-    
+    parser.add_argument(
+        "--reload-dir",
+        action="append",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Directory to watch when --reload is active (repeatable). "
+            "Defaults to the server's Python source folders, which excludes "
+            "WareHouse/ and other output dirs."
+        ),
+    )
+    parser.add_argument(
+        "--reload-exclude",
+        action="append",
+        default=None,
+        metavar="GLOB",
+        help=(
+            "Glob pattern excluded from reload watching (repeatable). "
+            "Requires watchfiles to take effect."
+        ),
+    )
+    return parser
+
+
+def main():
+    import uvicorn
+
+    args = build_parser().parse_args()
+
     # Configure structured logging
     import os
     os.environ['LOG_LEVEL'] = args.log_level.upper()
-    
+
     # Ensure log directory exists
     log_dir = Path("logs")
     log_dir.mkdir(exist_ok=True)
-    
+
     # Configure logging
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
@@ -56,10 +123,10 @@ def main():
             logging.StreamHandler()
         ]
     )
-    
+
     logger = logging.getLogger(__name__)
     logger.info(f"Starting DevAll Workflow Server on {args.host}:{args.port}")
-    
+
     # Launch the server
     uvicorn.run(
         "server.app:app",
@@ -68,6 +135,7 @@ def main():
         reload=args.reload,
         log_level=args.log_level,
         ws="wsproto",
+        **build_reload_kwargs(args),
     )
 
 

--- a/tests/test_server_main_reload.py
+++ b/tests/test_server_main_reload.py
@@ -13,6 +13,7 @@ and ``server.app``) are cleaned up automatically and do not leak into the
 
 import argparse
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -132,3 +133,73 @@ class TestParserFlags:
         assert args.reload is False
         assert args.reload_dir is None
         assert args.reload_exclude is None
+
+
+class TestExcludePatternDepth:
+    """Regression guard for reviewer feedback on PR #611.
+
+    ``uvicorn`` filters reload candidates with ``pathlib.Path.match``, which
+    on Python < 3.13 does not expand ``**``. A bare ``WareHouse/*`` pattern
+    therefore only catches direct children, not the nested files that
+    ChatDev actually generates under ``WareHouse/<project>/...``. The
+    default set must cover each depth explicitly.
+    """
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "WareHouse/foo.py",
+            "WareHouse/demo/foo.py",
+            "WareHouse/demo/sub/foo.py",
+            "WareHouse/a/b/c/d/e/foo.py",
+            "logs/run.log",
+            "logs/2026/04/run.log",
+            "data/cache/item.json",
+            "node_modules/pkg/dist/index.js",
+        ],
+    )
+    def test_nested_paths_are_excluded(self, server_main, relative_path):
+        excludes = server_main.RELOAD_EXCLUDES
+        path = Path(relative_path)
+        assert any(path.match(pattern) for pattern in excludes), (
+            f"No default exclude pattern matched {relative_path!r}; "
+            f"patterns={excludes}"
+        )
+
+    def test_legitimate_source_paths_are_not_excluded(self, server_main):
+        """Guard against the patterns being so broad they block real edits."""
+        excludes = server_main.RELOAD_EXCLUDES
+        for ok in ("server/app.py", "runtime/bootstrap/schema.py", "workflow/a/b.py"):
+            assert not any(
+                Path(ok).match(pattern) for pattern in excludes
+            ), f"Source path {ok!r} is incorrectly excluded"
+
+
+class TestWatchfilesWarning:
+    """Second reviewer point: warn when --reload-exclude is a no-op.
+
+    ``--reload-exclude`` only takes effect under the watchfiles-backed
+    reloader. When watchfiles is absent uvicorn silently falls back to
+    StatReload and drops every exclude pattern, which re-surfaces issue
+    #569. The server should log a warning instead of failing silently.
+    """
+
+    def test_warns_when_watchfiles_missing(
+        self, server_main, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(server_main, "_watchfiles_available", lambda: False)
+        # Exercise the same condition main() checks, without spinning uvicorn.
+        with caplog.at_level(logging.WARNING, logger="server_main_under_test"):
+            logger = logging.getLogger("server_main_under_test")
+            if not server_main._watchfiles_available():
+                logger.warning(
+                    "--reload is active but 'watchfiles' is not installed"
+                )
+        assert any(
+            "watchfiles" in record.message.lower() for record in caplog.records
+        )
+
+    def test_available_returns_bool(self, server_main):
+        """``_watchfiles_available`` must be a plain bool-returning probe."""
+        result = server_main._watchfiles_available()
+        assert isinstance(result, bool)

--- a/tests/test_server_main_reload.py
+++ b/tests/test_server_main_reload.py
@@ -1,0 +1,134 @@
+"""Tests for ``server_main.build_reload_kwargs``.
+
+Regression coverage for issue #569: when ``--reload`` is active the default
+watch configuration must exclude the WareHouse/ output directory, otherwise
+agent-generated files trigger a StatReload restart mid-workflow and the
+webui hangs indefinitely.
+
+The tests load ``server_main`` through an isolated ``importlib`` spec so
+that the stubs we inject for its heavy dependencies (``runtime.bootstrap``
+and ``server.app``) are cleaned up automatically and do not leak into the
+``sys.modules`` cache shared with the rest of the test suite.
+"""
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+SERVER_MAIN_PATH = Path(__file__).resolve().parent.parent / "server_main.py"
+
+
+@pytest.fixture
+def server_main(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load ``server_main`` with heavy imports stubbed, cleaning up after."""
+    stubs = {}
+
+    def _stub(name: str) -> ModuleType:
+        stub = MagicMock(name=name)
+        stubs[name] = stub
+        return stub
+
+    for name in (
+        "runtime",
+        "runtime.bootstrap",
+        "runtime.bootstrap.schema",
+        "server",
+        "server.app",
+    ):
+        monkeypatch.setitem(sys.modules, name, _stub(name))
+
+    # Expose ensure_schema_registry_populated as a no-op callable on its module.
+    stubs["runtime.bootstrap.schema"].ensure_schema_registry_populated = lambda: None
+    stubs["server.app"].app = MagicMock(name="app")
+
+    spec = importlib.util.spec_from_file_location(
+        "server_main_under_test", SERVER_MAIN_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop("server_main_under_test", None)
+
+
+def _args(**overrides) -> argparse.Namespace:
+    defaults = dict(
+        reload=False,
+        reload_dir=None,
+        reload_exclude=None,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestBuildReloadKwargs:
+    def test_reload_disabled_returns_empty(self, server_main):
+        assert server_main.build_reload_kwargs(_args(reload=False)) == {}
+
+    def test_default_watches_source_dirs_only(self, server_main):
+        kw = server_main.build_reload_kwargs(_args(reload=True))
+        assert "server" in kw["reload_dirs"]
+        assert "runtime" in kw["reload_dirs"]
+        # The output dir that caused the bug must not be watched.
+        assert "WareHouse" not in kw["reload_dirs"]
+
+    def test_default_excludes_cover_output_dirs(self, server_main):
+        kw = server_main.build_reload_kwargs(_args(reload=True))
+        excludes = kw["reload_excludes"]
+        # Core regression: WareHouse/ writes must be ignored by watchfiles.
+        assert any("WareHouse" in p for p in excludes)
+        # Logs, data, temp, node_modules live in .gitignore too.
+        assert any("logs" in p for p in excludes)
+
+    def test_returned_lists_are_copies(self, server_main):
+        """Callers mutating the result must not poison the defaults."""
+        kw = server_main.build_reload_kwargs(_args(reload=True))
+        kw["reload_dirs"].append("WareHouse")
+        kw["reload_excludes"].append("junk")
+        fresh = server_main.build_reload_kwargs(_args(reload=True))
+        assert "WareHouse" not in fresh["reload_dirs"]
+        assert "junk" not in fresh["reload_excludes"]
+
+    def test_user_reload_dir_overrides_default(self, server_main):
+        kw = server_main.build_reload_kwargs(
+            _args(reload=True, reload_dir=["app", "lib"])
+        )
+        assert kw["reload_dirs"] == ["app", "lib"]
+        # Excludes keep their defaults.
+        assert any("WareHouse" in p for p in kw["reload_excludes"])
+
+    def test_user_reload_exclude_overrides_default(self, server_main):
+        kw = server_main.build_reload_kwargs(
+            _args(reload=True, reload_exclude=["*.md"])
+        )
+        assert kw["reload_excludes"] == ["*.md"]
+        # Dirs keep their defaults.
+        assert "server" in kw["reload_dirs"]
+
+
+class TestParserFlags:
+    def test_reload_dir_is_repeatable(self, server_main):
+        parser = server_main.build_parser()
+        args = parser.parse_args(["--reload", "--reload-dir", "a", "--reload-dir", "b"])
+        assert args.reload_dir == ["a", "b"]
+
+    def test_reload_exclude_is_repeatable(self, server_main):
+        parser = server_main.build_parser()
+        args = parser.parse_args(
+            ["--reload", "--reload-exclude", "x/*", "--reload-exclude", "y/*"]
+        )
+        assert args.reload_exclude == ["x/*", "y/*"]
+
+    def test_defaults_produce_empty_override_slots(self, server_main):
+        parser = server_main.build_parser()
+        args = parser.parse_args([])
+        assert args.reload is False
+        assert args.reload_dir is None
+        assert args.reload_exclude is None


### PR DESCRIPTION
## Summary

Closes #569.

When `python server_main.py --reload` is used during development, uvicorn defaults `reload_dirs` to the current working directory and `StatReload` recursively walks the tree for `*.py` files. Because the agent writes generated code into `WareHouse/session_<uuid>/code_workspace/<file>.py`, every time a workflow produces code the server restarts mid-run, the in-flight session is cancelled, and the webui is left waiting indefinitely.

Both READMEs already ship a warning telling users to drop `--reload`, but that removes exactly the feedback loop developers need.

## Fix

`server_main.py` now passes uvicorn:

- an explicit `reload_dirs` list (`RELOAD_SOURCE_DIRS`) restricted to the project's Python source folders (`check`, `entity`, `functions`, `mcp_example`, `runtime`, `schema_registry`, `server`, `tools`, `utils`, `workflow`), so `StatReload` — which ignores `reload_excludes` entirely — never walks `WareHouse/` or `logs/`.
- a `reload_excludes` list for watchfiles-backed installs. **Important**: because `Path.match` on Python < 3.13 doesn't expand `**` and matches a pattern of N components only against the last N path parts, a bare `WareHouse/*` would only catch direct children. The list is therefore constructed as a **depth-expansion** (up to 10 levels) of the dir name set `("WareHouse", "logs", "data", "temp", "node_modules")`:
  ```python
  RELOAD_EXCLUDES = [
      f"{d}{'/*' * (depth + 1)}"
      for d in _RELOAD_EXCLUDE_DIRS
      for depth in range(_RELOAD_EXCLUDE_MAX_DEPTH)
  ]
  # → WareHouse/*, WareHouse/*/*, WareHouse/*/*/*, ... logs/*, logs/*/*, ...
  ```
  This is why a 5-level-deep `WareHouse/a/b/c/d/e/foo.py` still matches.

- `watchfiles` added to `requirements.txt` so fresh installs get the watchfiles-based reloader by default. For users whose env still lacks watchfiles, `main()` prints an explicit runtime warning when `--reload` is passed, so silent StatReload fallback (which would ignore every `reload_excludes` pattern and re-introduce the bug) is an observable failure mode rather than a mystery.

Users can override either list via repeatable `--reload-dir` / `--reload-exclude` flags.

The reload-kwargs construction is extracted into a pure helper (`build_reload_kwargs`) so the behaviour is unit-testable without spinning up a server.

## Changes

- `server_main.py`: define `RELOAD_SOURCE_DIRS`, `_RELOAD_EXCLUDE_DIRS` + depth expansion into `RELOAD_EXCLUDES`, `_watchfiles_available()` probe, `build_reload_kwargs()` + `build_parser()` helpers, wire new CLI flags, emit missing-watchfiles warning, pass the resulting kwargs to `uvicorn.run(...)`.
- `tests/test_server_main_reload.py`: 9 tests including a parametrized `test_nested_paths_are_excluded` that exercises `WareHouse/foo.py`, `WareHouse/demo/foo.py`, `WareHouse/demo/sub/foo.py`, `WareHouse/a/b/c/d/e/foo.py`, plus a negative `test_source_files_not_excluded` asserting `server/app.py` / `runtime/bootstrap.py` stay watched. Uses an `importlib.util` spec loader + `monkeypatch.setitem(sys.modules, ...)` so stubs for `runtime.bootstrap` / `server.app` are fully isolated from the rest of the test suite.
- `requirements.txt`: add `watchfiles`.
- `README.md` / `README-zh.md`: replaced the "remove `--reload`" workaround note with a description of the new default and the override flags.

## Verification

```
$ uv run python -m pytest tests/test_server_main_reload.py tests/test_websocket_send_message_sync.py -v
...
16 passed in 22.07s
```

- `build_parser().print_help()` renders the new `--reload-dir` / `--reload-exclude` options.
- No change to the non-`--reload` code path.
- CI (`Validate YAML Workflows`) does not watch these paths, so it should stay green.