### PR TITLE
fix: strip <think> tokens from reasoning model output

### DIFF
--- a/runtime/node/agent/providers/openai_provider.py
+++ b/runtime/node/agent/providers/openai_provider.py
@@ -2,6 +2,7 @@
 
 import base64
 import hashlib
+import re
 
 import binascii
 import os
@@ -383,18 +384,31 @@ class OpenAIProvider(ModelProvider):
                     type="function"
                 ))
         
+        content = self._get_attr(msg, "content") or ""
+        content = self._strip_thinking_tokens(content)
+
         return Message(
             role=MessageRole.ASSISTANT,
-            content=self._get_attr(msg, "content") or "",
+            content=content,
             tool_calls=tool_calls
         )
+
+    _THINK_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+
+    @classmethod
+    def _strip_thinking_tokens(cls, text: str) -> str:
+        """Strip <think>...</think> blocks from model output (e.g. DeepSeek-R1, MiniMax-M2.7)."""
+        if "<think>" not in text:
+            return text
+        return cls._THINK_PATTERN.sub("", text).strip()
 
     def _append_chat_response_output(self, timeline: List[Any], response: Any) -> None:
         """Add chat response to timeline, preserving tool_calls (Chat API compatible)."""
         msg = response.choices[0].message
+        content = self._strip_thinking_tokens(msg.content or "")
         assistant_msg = {
             "role": "assistant",
-            "content": msg.content or ""
+            "content": content
         }
 
         if getattr(msg, "tool_calls", None):


### PR DESCRIPTION
## Problem

Models with thinking/reasoning capabilities (DeepSeek-R1, MiniMax-M2.7, QwQ, Qwen3, etc.) include `<think>...</think>` blocks in their response content when used via OpenAI-compatible API endpoints. These internal reasoning tokens leak into:

1. **Agent output** — downstream nodes receive thinking tokens as part of the input
2. **Timeline content** — execution logs show raw thinking blocks
3. **Final workflow result** — end users see `<think>` tags in the output

## Root Cause

`OpenAIProvider._deserialize_chat_response()` and `_append_chat_response_output()` pass raw `content` from model responses without filtering reasoning tokens.

## Fix

Add `_strip_thinking_tokens()` classmethod to `OpenAIProvider`:

- Uses regex `<think>.*?</think>\s*` with `re.DOTALL` to strip thinking blocks
- Fast path: skips regex if `<think>` substring not found (zero-cost for non-thinking models)
- Applied in both deserialization paths (`_deserialize_chat_response` and `_append_chat_response_output`)

## Testing

Verified with MiniMax-M2.7 (thinking model) in a Writer→Reviewer workflow:
- **Before fix**: `<think>` blocks leaked into Reviewer input and final output
- **After fix**: Clean output, no thinking tokens visible

## Notes

- This is a minimal, targeted fix in the OpenAI provider only
- The Gemini provider uses a different content structure (`MessageBlock`) and would need separate handling if Gemini models add thinking tokens
- No existing tests were broken