### PR TITLE
fix(security): replace yaml.load(FullLoader) with yaml.safe_load

### DIFF
--- a/entity/config_loader.py
+++ b/entity/config_loader.py
@@ -27,7 +27,7 @@ def load_design_from_mapping(data: Mapping[str, Any], *, source: str | None = No
 def load_design_from_file(path: Path) -> DesignConfig:
     """Read a YAML file and parse it into a :class:`DesignConfig`."""
     with path.open("r", encoding="utf-8") as handle:
-        data = yaml.load(handle, Loader=yaml.FullLoader)
+        data = yaml.safe_load(handle)
     if not isinstance(data, Mapping):
         raise ConfigError("YAML root must be a mapping", path=str(path))
     return load_design_from_mapping(data, source=str(path))

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -3,4 +3,4 @@ import yaml
 
 def read_yaml(path) -> Dict[str, Any]:
     with open(path, mode="r", encoding="utf-8") as f:
-        return yaml.load(f, Loader=yaml.FullLoader)
+        return yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- Replace `yaml.load(f, Loader=yaml.FullLoader)` with `yaml.safe_load(f)` in `utils/io_utils.py` and `entity/config_loader.py`
- The rest of the codebase already uses `yaml.safe_load` (e.g. `server/services/workflow_storage.py`, `entity/configs/node/skills.py`, `runtime/node/agent/skills/manager.py`)
- These two files are the only remaining ones using the less safe `FullLoader`

## Vulnerability Details

`yaml.FullLoader` still supports certain Python object tags (like `!!python/object`), which can be exploited for arbitrary code execution when loading YAML from untrusted sources. `yaml.safe_load` restricts loading to standard YAML tags only, which is the recommended safe default.

The other YAML loading sites in this codebase already use `yaml.safe_load`. These two were overlooked.

## Files Changed
- `utils/io_utils.py:6` — `yaml.load(f, Loader=yaml.FullLoader)` → `yaml.safe_load(f)`
- `entity/config_loader.py:30` — `yaml.load(handle, Loader=yaml.FullLoader)` → `yaml.safe_load(handle)`

## Test plan
- [ ] Run existing tests to verify YAML loading still works correctly
- [ ] Verify workflow configs can still be loaded and parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)