### PR TITLE
fix: cap ThreadPoolExecutor max_workers to prevent resource exhaustion

### DIFF
--- a/workflow/executor/parallel_executor.py
+++ b/workflow/executor/parallel_executor.py
@@ -1,9 +1,12 @@
 """Parallel execution helpers that eliminate duplicated code."""
 
 import concurrent.futures
+import os
 from typing import Any, Callable, List, Tuple
 
 from utils.log_manager import LogManager
+
+MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
 
 
 class ParallelExecutor:
@@ -103,7 +106,7 @@ class ParallelExecutor:
         """
         self.log_manager.debug(f"Executing {len(items)} items in parallel")
         
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(items)) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(items), MAX_WORKERS)) as executor:
             futures = []
             for item in items:
                 future = executor.submit(executor_func, item)


### PR DESCRIPTION
## Summary
- Cap `ThreadPoolExecutor(max_workers=len(items))` to `min(len(items), MAX_WORKERS)` in `workflow/executor/parallel_executor.py`
- Prevents creating an unbounded number of threads when processing large batches of items

## Bug Details

In `workflow/executor/parallel_executor.py` (line 106), the parallel executor creates a thread pool with `max_workers=len(items)`:

```python
with concurrent.futures.ThreadPoolExecutor(max_workers=len(items)) as executor:
```

If a workflow contains many parallel nodes, this could create thousands of threads, causing:
- Excessive memory usage
- Thread scheduling overhead that degrades performance
- Potential OOM crashes on resource-constrained systems

Python's own `ThreadPoolExecutor` default is `min(32, os.cpu_count() + 4)`, which is a well-tested heuristic.

## Fix

Added a `MAX_WORKERS` constant following the standard library pattern and capped the pool size:

```python
MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
...
with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(items), MAX_WORKERS)) as executor:
```

## Test plan
- [ ] Run workflows with parallel nodes and verify they still execute correctly
- [ ] Test with a large number of parallel items (>32) to verify they are properly throttled

🤖 Generated with [Claude Code](https://claude.com/claude-code)