### PR TITLE
fix: replace atexit with BackgroundTask for temp zip cleanup

### DIFF
--- a/server/routes/sessions.py
+++ b/server/routes/sessions.py
@@ -1,4 +1,3 @@
-import atexit
 import re
 import shutil
 import tempfile
@@ -6,6 +5,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 
 from server.settings import WARE_HOUSE_DIR
 from utils.exceptions import ResourceNotFoundError, ValidationError
@@ -64,13 +64,12 @@ async def download_session(session_id: str):
             if zip_path.exists():
                 zip_path.unlink()
 
-        atexit.register(cleanup_zip)
-
         return FileResponse(
             path=zip_path,
             filename=f"{dir_name}.zip",
             media_type="application/zip",
             headers={"Content-Disposition": f"attachment; filename={dir_name}.zip"},
+            background=BackgroundTask(cleanup_zip),
         )
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc))


### PR DESCRIPTION
## Summary
- Replace `atexit.register(cleanup_zip)` with Starlette's `BackgroundTask` for cleaning up temporary zip files after session downloads
- `atexit` handlers only run at process shutdown, so every download accumulates a temp zip file on disk until the server restarts

## Bug Details

In `server/routes/sessions.py`, after creating a temporary zip archive for download, the cleanup is registered via `atexit`:

```python
def cleanup_zip():
    if zip_path.exists():
        zip_path.unlink()

atexit.register(cleanup_zip)
```

**Problem:** `atexit` handlers only run when the Python process exits. In a long-running server, this means:
1. Each download creates a new temp zip file
2. None of them are cleaned up until the server restarts
3. Under high usage, temp files accumulate and consume disk space
4. Each `atexit.register` call also adds to a growing list of callbacks

**Fix:** Use Starlette's `BackgroundTask` which runs after the HTTP response is fully sent.

## Test plan
- [ ] Download a session and verify the zip file is created and served correctly
- [ ] Verify the temp zip file is deleted after the download completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)